### PR TITLE
Add support for additional runs-on labels alongside the matrix.os

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Any and all settings which affect the behavior of the generative plugin should b
 - `githubWorkflowJavaVersions` : `Seq[String]` – A list of Java versions, using [Jabba](https://github.com/shyiko/jabba) syntax, which will be used to `build` your project. Note that the `publish` job will always run under the very first of these versions. Defaults to `[adopt@1.8]`.
 - `githubWorkflowScalaVersions` : `Seq[String]` – A list of Scala versions which will be used to `build` your project. Defaults to `crossScalaVersions` in `build`, and simply `scalaVersion` in `publish`.
 - `githubWorkflowOSes` : `Seq[String]` – A list of operating systems, which will be ultimately passed to [the `runs-on:` directive](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on), on which to `build` your project. Defaults to `ubuntu-latest`. Note that, regardless of the value of this setting, only `ubuntu-latest` will be used for the `publish` job. This setting only affects `build`.
+- `githubWorkflowBuildRunsOnExtraLabels` : `Seq[String]` - A list of additional runs-on labels, which will be combined with the matrix.os from `githubWorkflowOSes` above allowing for singling out more specific runners.
 
 #### `publish` Job
 

--- a/src/main/scala/sbtghactions/GenerativeKeys.scala
+++ b/src/main/scala/sbtghactions/GenerativeKeys.scala
@@ -33,6 +33,7 @@ trait GenerativeKeys {
   lazy val githubWorkflowBuildMatrixAdditions = settingKey[Map[String, List[String]]]("A map of additional matrix dimensions for the build job. Each list should be non-empty. (default: {})")
   lazy val githubWorkflowBuildMatrixInclusions = settingKey[Seq[MatrixInclude]]("A list of matrix inclusions (default: [])")
   lazy val githubWorkflowBuildMatrixExclusions = settingKey[Seq[MatrixExclude]]("A list of matrix exclusions (default: [])")
+  lazy val githubWorkflowBuildRunsOnExtraLabels = settingKey[Seq[String]]("A list of additional labels to append to each run of the matrix executions")
 
   lazy val githubWorkflowBuildPreamble = settingKey[Seq[WorkflowStep]]("A list of steps to insert after base setup but before compiling and testing (default: [])")
   lazy val githubWorkflowBuildPostamble = settingKey[Seq[WorkflowStep]]("A list of steps to insert after comping and testing but before the end of the build job (default: [])")

--- a/src/main/scala/sbtghactions/GenerativePlugin.scala
+++ b/src/main/scala/sbtghactions/GenerativePlugin.scala
@@ -289,13 +289,18 @@ ${indent(rendered.mkString("\n"), 1)}"""
 
     val declareShell = job.oses.exists(_.contains("windows"))
 
+    val runsOn = if (job.runsOnExtraLabels.isEmpty)
+      s"$${{ matrix.os }}"
+    else
+      job.runsOnExtraLabels.mkString(s"[ $${{ matrix.os }}, ", ", ", " ]" )
+
     val body = s"""name: ${wrap(job.name)}${renderedNeeds}${renderedCond}
 strategy:
   matrix:
     os:${compileList(job.oses, 3)}
     scala:${compileList(job.scalas, 3)}
     java:${compileList(job.javas, 3)}${renderedMatrices}
-runs-on: $${{ matrix.os }}${renderedEnv}
+runs-on: ${runsOn}${renderedEnv}
 steps:
 ${indent(job.steps.map(compileStep(_, sbt, declareShell = declareShell)).mkString("\n\n"), 1)}"""
 
@@ -355,6 +360,7 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}"""
     githubWorkflowBuildMatrixAdditions := Map(),
     githubWorkflowBuildMatrixInclusions := Seq(),
     githubWorkflowBuildMatrixExclusions := Seq(),
+    githubWorkflowBuildRunsOnExtraLabels := Seq(),
 
     githubWorkflowBuildPreamble := Seq(),
     githubWorkflowBuildPostamble := Seq(),
@@ -579,7 +585,8 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}"""
           javas = githubWorkflowJavaVersions.value.toList,
           matrixAdds = githubWorkflowBuildMatrixAdditions.value,
           matrixIncs = githubWorkflowBuildMatrixInclusions.value.toList,
-          matrixExcs = githubWorkflowBuildMatrixExclusions.value.toList)) ++ publishJobOpt ++ githubWorkflowAddedJobs.value
+          matrixExcs = githubWorkflowBuildMatrixExclusions.value.toList,
+          runsOnExtraLabels = githubWorkflowBuildRunsOnExtraLabels.value.toList )) ++ publishJobOpt ++ githubWorkflowAddedJobs.value
     })
 
   private val generateCiContents = Def task {

--- a/src/main/scala/sbtghactions/WorkflowJob.scala
+++ b/src/main/scala/sbtghactions/WorkflowJob.scala
@@ -25,7 +25,8 @@ final case class WorkflowJob(
     oses: List[String] = List("ubuntu-latest"),
     scalas: List[String] = List("2.13.1"),
     javas: List[String] = List("adopt@1.8"),
-    needs: List[String] = Nil,
+    needs: List[String] = List(),
     matrixAdds: Map[String, List[String]] = Map(),
     matrixIncs: List[MatrixInclude] = List(),
-    matrixExcs: List[MatrixExclude] = List())
+    matrixExcs: List[MatrixExclude] = List(),
+    runsOnExtraLabels: List[String] = List())

--- a/src/test/scala/sbtghactions/GenerativePluginSpec.scala
+++ b/src/test/scala/sbtghactions/GenerativePluginSpec.scala
@@ -390,6 +390,26 @@ class GenerativePluginSpec extends Specification {
       uses: actions/checkout@v2"""
     }
 
+    "compile a job with extra runs-on labels" in {
+      compileJob(
+        WorkflowJob(
+          "job",
+          "my-name",
+          List(
+            WorkflowStep.Run(List("echo hello"))),
+          runsOnExtraLabels = List("runner-label", "runner-group"),
+        ), "") mustEqual """job:
+  name: my-name
+  strategy:
+    matrix:
+      os: [ubuntu-latest]
+      scala: [2.13.1]
+      java: [adopt@1.8]
+  runs-on: [ ${{ matrix.os }}, runner-label, runner-group ]
+  steps:
+    - run: echo hello"""
+    }
+
     "produce an error when compiling a job with `include` key in matrix" in {
       compileJob(
         WorkflowJob(


### PR DESCRIPTION
I needed this in order to select an internal runner to run integration tests