### PR TITLE
Set homepage in build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,7 @@ ThisBuild / baseVersion := "0.9"
 ThisBuild / organization := "com.codecommit"
 ThisBuild / publishGithubUser := "djspiewak"
 ThisBuild / publishFullName := "Daniel Spiewak"
+ThisBuild / homepage := Some(url("https://github.com/djspiewak/sbt-github-actions"))
 
 ThisBuild / scalaVersion := "2.12.10"
 


### PR DESCRIPTION
This sets the homepage setting to https://github.com/djspiewak/sbt-github-actions.
It enables Scala Steward to link to this page, the GitHub release notes
and version diff in its pull requests.