### PR TITLE
Fix example of appending to githubWorkflowPublishTargetBranches

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This is assuming that you *only* wish to publish tags. If you also wish to publi
 
 ```scala
 ThisBuild / githubWorkflowPublishTargetBranches += 
-  Seq(RefPredicate.StartsWith(Ref.Tag("v")))
+  RefPredicate.StartsWith(Ref.Tag("v"))
 ```
 
 Note the use of `+=` rather than `:=`.


### PR DESCRIPTION
The example of appending to `githubWorkflowPublishTargetBranches` fails with:
```sbt
build.sbt:23: error: No Append.Value[Seq[sbtghactions.RefPredicate], Seq[sbtghactions.GenerativePlugin.autoImport.RefPredicate.StartsWith]] found, so Seq[sbtghactions.GenerativePlugin.autoImport.RefPredicate.StartsWith] cannot be appended to Seq[sbtghactions.RefPredicate]
ThisBuild / githubWorkflowPublishTargetBranches += Seq(RefPredicate.StartsWith(Ref.Tag("v")))
                                                ^
[error] Type error in expression
```
This is because a `Seq[RefPredicate]` instead of a sole `RefPredicate` is appended.