### PR TITLE
Recommend latest version of olafurpg/setup-gpg

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ One issue you might run into is an incompatible gpg version (see https://github.
 
 ```scala
 ThisBuild / githubWorkflowPublishPreamble +=
-  WorkflowStep.Use("olafurpg", "setup-gpg", "v2")
+  WorkflowStep.Use("olafurpg", "setup-gpg", "v3")
 
 ThisBuild / githubWorkflowPublish := Seq(
   WorkflowStep.Sbt(


### PR DESCRIPTION
Using v2 leads to the following warning, which is fixed in v3:
```
The `add-path` command is deprecated and will be disabled on November 16th. Please upgrade to using Environment Files.
For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```