### PR TITLE
Add log message in case of missing `name` key

### DIFF
--- a/src/main/scala/sbtghactions/GitHubActionsPlugin.scala
+++ b/src/main/scala/sbtghactions/GitHubActionsPlugin.scala
@@ -82,9 +82,13 @@ object GitHubActionsPlugin extends AutoPlugin {
                         map.asScala.toMap map { case (k, v) => k.toString -> recursivelyConvert(v) }
                     }
                   }
-                } filter { map =>
-                  map("name") == name
-                }
+                } filter ( _ get "name" match {
+                  case Some(nameValue) =>
+                    nameValue == name
+                  case None =>
+                    log.warn("GitHub action yml file does not contain 'name' key")
+                    false
+                })
 
                 results.headOption getOrElse {
                   log.warn("unable to find or parse workflow YAML definition")


### PR DESCRIPTION
This PR handles the case of a missing `name` key in the `yml` action file:

I had a file with a missing `name` and got runtime exception with not enough details.
Instead of getting an exception in runtime, this PR logs this event with (hopefully) a more descriptive error message.
