### PR TITLE
setup-gpg shouldn't be needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,7 @@ ThisBuild / githubWorkflowPublishTargetBranches +=
 
 Note the use of `+=` rather than `:=`.
 
-One issue you might run into is an incompatible gpg version (see https://github.com/olafurpg/sbt-ci-release/issues/95), you can work around this by installing gpg 1.4.0 by using Olafur's [excellent `setup-gpg` action](https://github.com/olafurpg/setup-gpg):
-
 ```scala
-ThisBuild / githubWorkflowPublishPreamble +=
-  WorkflowStep.Use("olafurpg", "setup-gpg", "v3")
-
 ThisBuild / githubWorkflowPublish := Seq(
   WorkflowStep.Sbt(
     List("ci-release"),


### PR DESCRIPTION
This is no longer necessary, since https://github.com/olafurpg/sbt-ci-release/releases/tag/v1.5.5