### PR TITLE
Truly match all branches (including slashes)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ name: Continuous Integration
 
 on:
   pull_request:
-    branches: ['*']
+    branches: ['**']
   push:
-    branches: ['*']
+    branches: ['**']
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/main/scala/sbtghactions/GenerativePlugin.scala
+++ b/src/main/scala/sbtghactions/GenerativePlugin.scala
@@ -459,7 +459,7 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}"""
     githubWorkflowScalaVersions := crossScalaVersions.value,
     githubWorkflowOSes := Seq("ubuntu-latest"),
     githubWorkflowDependencyPatterns := Seq("**/*.sbt", "project/build.properties"),
-    githubWorkflowTargetBranches := Seq("*"),
+    githubWorkflowTargetBranches := Seq("**"),
     githubWorkflowTargetTags := Seq(),
 
     githubWorkflowEnv := Map("GITHUB_TOKEN" -> s"$${{ secrets.GITHUB_TOKEN }}"),
@@ -486,10 +486,6 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}"""
         normalizeSeparators(path.toString)
     }
   }
-
-  // cannot contain '\', '/', '"', ':', '<', '>', '|', '*', or '?'
-  private def sanitizeTarget(str: String): String =
-    List('\\', '/', '"', ':', '<', '>', '|', '*', '?').foldLeft(str)(_.replace(_, '_'))
 
   override def globalSettings = Seq(
     internalTargetAggregation := Seq(),

--- a/src/sbt-test/sbtghactions/check-and-regenerate/expected-ci.yml
+++ b/src/sbt-test/sbtghactions/check-and-regenerate/expected-ci.yml
@@ -9,9 +9,9 @@ name: Continuous Integration
 
 on:
   pull_request:
-    branches: ['*']
+    branches: ['**']
   push:
-    branches: ['*']
+    branches: ['**']
     tags: [v*]
 
 env:

--- a/src/sbt-test/sbtghactions/non-existent-target/.github/workflows/ci.yml
+++ b/src/sbt-test/sbtghactions/non-existent-target/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ name: Continuous Integration
 
 on:
   pull_request:
-    branches: ['*']
+    branches: ['**']
   push:
-    branches: ['*']
+    branches: ['**']
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
See https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#patterns-to-match-branches-and-tags



Pattern | Description | Example matches
-- | -- | --
'*' | Matches all branch and tag names that don't contain a slash (/). The * character is a special character in YAML. When you start a pattern with *, you must use quotes. | mainreleases
'**' | Matches all branch and tag names. This is the default behavior when you don't use a branches or tags filter. | all/the/branchesevery/tag

This covers the common pattern to maintain `series/x.y` branches