### PR TITLE
Add new line at end of githubWorkflowGenerate files

### DIFF
--- a/src/main/scala/sbtghactions/GenerativePlugin.scala
+++ b/src/main/scala/sbtghactions/GenerativePlugin.scala
@@ -726,6 +726,7 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}"""
       val ciWriter = new BufferedWriter(new FileWriter(ciYml))
       try {
         ciWriter.write(ciContents)
+        ciWriter.newLine()
       } finally {
         ciWriter.close()
       }
@@ -733,6 +734,7 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}"""
       val cleanWriter = new BufferedWriter(new FileWriter(cleanYml))
       try {
         cleanWriter.write(cleanContents)
+        cleanWriter.newLine()
       } finally {
         cleanWriter.close()
       }


### PR DESCRIPTION
This PR resolves https://github.com/djspiewak/sbt-github-actions/issues/69. As can be seen, the solution is a very simple one where we just use `BufferedWriter.newLine` after we write the contents. The advantage here is none of the tests needed to be adjusted since the tests compare `String` outputs from `compileWorkflow` which happens before any file generated and hence the disadvantage is that this codepath is not tested since there is no existing test that makes use of `githubWorkflowGenerate`.

@djspiewak Do you want me to write a test for this, and if so how would you like to do it? Simplest thing I can think of is to move some code out of `githubWorkflowGenerate` into a function and to write a simple test that some generated files end with a new line?